### PR TITLE
Http get functionality

### DIFF
--- a/get21.py
+++ b/get21.py
@@ -32,14 +32,26 @@ def get21(uri, wait_timeout=5, headers=None):
     if not is_compatible():
         return
 
+    # Create a start timer
     start = dt.datetime.now()
-    ret = requests.get(uri, timeout=wait_timeout, headers=headers)
+
+    # Initiate the HTTP GET
+    res = {}
+    try:
+        ret = requests.get(uri, timeout=wait_timeout, headers=headers)
+
+        # Success
+        res = {'status_code' : ret.status_code, 'reason' : ret.reason}
+
+    except requests.exceptions.RequestException as ex:
+        # Failure
+        res = {'status_code' : 500, 'reason' : "{0}".format(ex)}
+
+
+    # Create an end timer and get elapsed time in milliseconds
     finish = dt.datetime.now()
-
-    # Get elapsed time in milliseconds
     elapsed = int((finish - start).total_seconds() * 1000)
-
-    res = {'status_code' : ret.status_code, 'reason' : ret.reason, 'elapsed_ms': elapsed}
+    res['elapsed_ms'] = elapsed
 
     info = {
         'get': res,

--- a/get21.py
+++ b/get21.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import json
+import sys
+import requests
+import datetime as dt
+
+from ping21 import is_compatible, get_server_info
+
+__all__ = ["get21"]
+
+
+def get21(uri, wait_timeout=5, headers=None):
+    """ runs HTTP GET against the url.
+
+    Args:
+        url (str): A url to run GET against.
+        wait_timeout (int): Optional timeout in seconds for request (default is 5)
+        headers (dict): Optional headers to send with the request
+
+    Raises:
+        ValueError: if the url is malformed or GET cannot be performed on it.
+    Returns:
+        dict: A dictionary containing GET information.
+
+    """
+    # Default the headers
+    if headers is None:
+        headers = {}
+
+    if not is_compatible():
+        return
+
+    start = dt.datetime.now()
+    ret = requests.get(uri, timeout=wait_timeout, headers=headers)
+    finish = dt.datetime.now()
+
+    # Get elapsed time in milliseconds
+    elapsed = int((finish - start).total_seconds() * 1000)
+
+    res = {'status_code' : ret.status_code, 'reason' : ret.reason, 'elapsed_ms': elapsed}
+
+    info = {
+        'get': res,
+        'server': get_server_info(),
+    }
+    return info
+
+if __name__ == '__main__':
+    url = sys.argv[1]
+    data = get21(url)
+    formatted_data = json.dumps(data, indent=4, sort_keys=True)
+    print(formatted_data)

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -36,6 +36,23 @@ paths:
             type: object
       summary: Return ping statistics between this device and a given domain
         or IP.
+  /get:
+    get:
+      consumes: [application/x-www-form-urlencoded]
+      produces: [application/json]
+      responses:
+        200:
+          description: HTTP GET statistics and information on server location.
+          schema:
+            properties:
+              get:
+                elapsed_ms: {type: integer}
+                reason: {type: string}
+                status_code: {type: integer}
+                type: object
+              server: {$ref: '#/definitions/Server'}
+            type: object
+      summary: Return HTTP GET statistics between this device and a given URL.
 schemes: [http]
 swagger: '2.0'
 x-21-manifest-path: /manifest

--- a/ping21-server.py
+++ b/ping21-server.py
@@ -16,6 +16,7 @@ from two1.wallet.two1_wallet import Wallet
 from two1.bitserv.flask import Payment
 
 from ping21 import ping21, getHostname
+from get21 import get21
 
 app = Flask(__name__)
 
@@ -66,6 +67,26 @@ def ping():
     except ValueError as e:
         return 'HTTP Status 400: {}'.format(e.args[0]), 400
 
+
+@app.route('/get')
+@payment.required(5)
+def get():
+    """ Runs an HTTP GET on the provided url
+
+    Returns: HTTPResponse 200 with a json containing the request info.
+    HTTP Response 400 if no uri is specified or the uri is malformed/cannot be requested.
+    """
+    try:
+        uri = request.args['uri']
+    except KeyError:
+        return 'HTTP Status 400: URI query parameter is missing from your request.', 400
+
+    try:
+        data = get21(uri)
+        response = json.dumps(data, indent=4, sort_keys=True)
+        return response
+    except ValueError as e:
+        return 'HTTP Status 400: {}'.format(e.args[0]), 400
 
 if __name__ == '__main__':
     import click

--- a/ping21.py
+++ b/ping21.py
@@ -9,7 +9,7 @@ import subprocess
 import sys
 from urllib.parse import urlparse
 
-__all__ = ["ping21", "getHostname"]
+__all__ = ["ping21", "getHostname", "is_compatible", "get_server_info"]
 
 def getHostname(uri):
     """ Cleans a provided uri


### PR DESCRIPTION
For uptime monitoring services, the ability to perform HTTP requests against an application is needed in addition to a standard PING request.  This allows the user to understand not only if the server is reachable, but also if the web application running on the server is functioning as expected.

This pull request adds a simple HTTP GET capability to the Ping21 server with a single new endpoint.  If the customer would like to run an HTTP GET against a url, they can hit the "/get" endpoint and will get stats about the http request performed.

The response will include:
- HTTP status code
- HTTP reason text
- Elapsed time for the request to complete in milliseconds
- Sever information about the node (same as existing Ping endpoint)
